### PR TITLE
Feature/param instead of constant

### DIFF
--- a/NuGet/QueryDesigner.nuspec
+++ b/NuGet/QueryDesigner.nuspec
@@ -2,14 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id> QueryDesigner </id>
-    <version>3.0.1</version>
+    <version>3.0.2</version>
     <authors>Vladislav Zhukov</authors>
     <owners>mrxten</owners>
     <licenseUrl>https://raw.githubusercontent.com/mrxten/QueryDesigner/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/mrxten/QueryDesigner</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>QueryDesigner provides way of creating complex IQueryable filtering based on dynamic expression trees.</description>
-    <releaseNotes>Added DateTimeOffset to available cast types.</releaseNotes>
+    <releaseNotes>Changed logics of expression creating on value. Using of parameter instead of constant.</releaseNotes>
     <copyright>Copyright 2020</copyright>
     <tags>linq query filtering entity-framework</tags>
   </metadata>

--- a/src/QueryDesignerCore/QueryDesignerCore.csproj
+++ b/src/QueryDesignerCore/QueryDesignerCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <VersionPrefix>3.0.2</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>QueryDesignerCore</AssemblyName>


### PR DESCRIPTION
Изменена логика формирования выражения над Value. Ранее использовался Expression.Constant, что при компиляции EF-ом приводило к встраиванию параметров в тело запроса. Сейчас же данные параметры выносятся в параметры SQL запрос, что снижает нагрузку на кеш базы данных.